### PR TITLE
Add performance timing to serialisation unit tests

### DIFF
--- a/tests/unitTestClient.py
+++ b/tests/unitTestClient.py
@@ -6,14 +6,17 @@
 # Description:
 #     This script provides unit tests for the client module, which handles data
 #     serialization and network communication with a server. The tests cover
-#     serialization in binary, JSON, and XML formats and ensure that the client's
-#     main function appropriately manages socket connections and sends data as
-#     expected.
+#     serialization in binary, JSON, and XML formats and include performance 
+#     measurements to compare the execution time for each serialization method.
+#     Additionally, it ensures that the client's main function appropriately 
+#     manages socket connections and sends data as expected.
 #
 #     These tests aim to verify that the client module correctly serializes data
 #     into the specified format and handles socket communication effectively,
 #     using mocks for socket methods to ensure that no actual network communication
-#     is performed during the tests.
+#     is performed during the tests. The inclusion of timing measurements provides
+#     insights into the performance characteristics of each serialization method,
+#     aiding in the selection of the most efficient approach.
 #
 # Usage:
 #     Run this script directly to execute all unit tests for the client module.
@@ -28,72 +31,57 @@ import sys
 import json
 import xml.etree.ElementTree as ET
 import pickle
+import time
 
-
-# Adjust the system path to include the server directory
-project_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-src_dir = os.path.join(project_dir, "src")
-sys.path.append(src_dir)
-
-try:
-    import client
-
-    print("client module imported successfully!")
-except ModuleNotFoundError:
-    print("Failed to import client module. Check the path and existence of client.py.")
-
+# Append the path to the src directory so that Python can find the modules
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+import client  # Import module
 
 class TestClient(unittest.TestCase):
-    """
-    A test suite for verifying the functionality of the client's data serialization.
-
-    This class contains tests that check the serialization and deserialization
-    capabilities of a client module that supports multiple data formats:
-    binary (using pickle), JSON, and XML. It ensures that the data, once serialized
-    and then deserialized, retains its original structure and content.
-    """
-
     def test_serialize_data_binary(self):
-        """Test serialization of data into binary format."""
-        data = {"name": "John", "age": 30, "city": "New York"}
-        serialized_data = client.serialize_data(data, "binary")
+        """Test serialization of data into binary format and measure performance."""
+        data = {'name': 'John', 'age': 30, 'city': 'New York'}
+        start_time = time.perf_counter()
+        serialized_data = client.serialize_data(data, 'binary')
         deserialized_data = pickle.loads(serialized_data)
+        end_time = time.perf_counter()
+        print(f"Binary serialization/deserialization time: {end_time - start_time} seconds")
         self.assertEqual(deserialized_data, data)
 
     def test_serialize_data_json(self):
-        """Test serialization of data into JSON format."""
-        data = {"name": "John", "age": 30, "city": "New York"}
-        serialized_data = client.serialize_data(data, "json")
+        """Test serialization of data into JSON format and measure performance."""
+        data = {'name': 'John', 'age': 30, 'city': 'New York'}
+        start_time = time.perf_counter()
+        serialized_data = client.serialize_data(data, 'json')
         deserialized_data = json.loads(serialized_data.decode())
+        end_time = time.perf_counter()
+        print(f"JSON serialization/deserialization time: {end_time - start_time} seconds")
         self.assertEqual(deserialized_data, data)
 
     def test_serialize_data_xml(self):
-        """Test serialization of data into XML format."""
-        data = {"name": "John", "age": 30, "city": "New York"}
-        serialized_data = client.serialize_data(data, "xml")
+        """Test serialization of data into XML format and measure performance."""
+        data = {'name': 'John', 'age': 30, 'city': 'New York'}
+        start_time = time.perf_counter()
+        serialized_data = client.serialize_data(data, 'xml')
         root = ET.fromstring(serialized_data)
-        deserialized_data = {
-            child.tag: int(child.text) if child.tag == "age" else child.text
-            for child in root
-        }
+        deserialized_data = {child.tag: int(child.text) if child.tag == 'age' else child.text for child in root}
+        end_time = time.perf_counter()
+        print(f"XML serialization/deserialization time: {end_time - start_time} seconds")
         self.assertEqual(deserialized_data, data)
 
-    @patch("socket.socket")
+    @patch('socket.socket')
     def test_main(self, mock_socket_class):
         """Test the main function for proper socket usage."""
         mock_socket_instance = MagicMock()
         mock_socket_class.return_value = mock_socket_instance
-        mock_socket_instance.connect.return_value = (
-            None  # Explicitly return None for clarity
-        )
+        mock_socket_instance.connect.return_value = None  # Explicitly return None for clarity
 
         # Call the main function
         client.main()
 
         # Verify that connect was called
-        mock_socket_instance.connect.assert_called_with(("localhost", 12345))
+        mock_socket_instance.connect.assert_called_with(('localhost', 12345))
         # Add any additional behavior checks such as sendall calls etc.
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit introduces timing measurements for the serialisation methods in the unit tests of the client module. The changes include:

- Implementation of `time.perf_counter()` to measure the execution time for serialising and deserialising data in binary, JSON, and XML formats.
- Updated documentation headers to reflect the inclusion of performance testing.
- These measurements will help identify the most efficient serialisation method based on the execution time.

This enhancement is crucial for optimising serialisation performance and making informed decisions about data handling strategies in the client module.